### PR TITLE
Fixed incorrect name space for new collections and added auto-correct

### DIFF
--- a/app/Console/Commands/MakeCollection.php
+++ b/app/Console/Commands/MakeCollection.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
 
 class MakeCollection extends Command
 {
@@ -45,8 +46,17 @@ class MakeCollection extends Command
      */
     public function handle()
     {
+        $collectionName = $this->argument('name');
+
+        if(ctype_lower($collectionName) || Str::singular($collectionName) != $collectionName) {
+            $proposedName = Str::singular(ucfirst(strtolower($collectionName)));
+            if ($this->confirm('"'.$collectionName.'" does not currently follow the standard naming convention for collections. Would you like to use "'.$proposedName.'" instead?')) {
+                $collectionName = $proposedName;
+            }
+        }
+
         $options = [
-            'name' => $this->argument('name'),
+            'name' => 'Collections\\'.$this->argument('name'),
             '-a' => $this->option('all'),
             '-c' => $this->option('controller'),
             '-f' => $this->option('factory'),


### PR DESCRIPTION
### Fixes

New collections are now saved in the correct namespace (`App\Collections`) rather than in the default model location (`App`)

---

### New features

**Added "intelligent" auto correct feature when creating collections**

When attempting to create a collection (`php artisan make:collection <name>`) with a plural or lowercase name, the command will ask if you want to correct it:

![image](https://user-images.githubusercontent.com/3238125/88977443-d43e7d00-d2b5-11ea-9964-58ef6b5d70e2.png)
